### PR TITLE
Update create and alter table statements to use execute

### DIFF
--- a/lib/e2e.spec.ts
+++ b/lib/e2e.spec.ts
@@ -76,4 +76,14 @@ describe("rqliteDialect", function () {
       ]);
     });
   });
+
+  describe("alterTable", function () {
+    it("should add a field to the table", async function () {
+      await knex.schema.alterTable(TABLE_NAME, function (table) {
+        table.integer("age").notNullable().defaultTo(0);
+      });
+
+      assert.equal(await knex.schema.hasColumn(TABLE_NAME, "age"), true);
+    });
+  });
 });

--- a/lib/rqliteDialect.ts
+++ b/lib/rqliteDialect.ts
@@ -135,7 +135,7 @@ export class RqliteDialect extends Client implements Client_ {
       useExecute = EXECUTE_METHODS.indexOf(obj.method) > -1;
     }
 
-    if (sql.indexOf("drop table ") === 0) {
+    if (/^(drop|create|alter) table\s+/.test(sql)) {
       useExecute = true;
     }
 


### PR DESCRIPTION
Attempting to create/alter tables in recent/current versions of rqlite
results in an error. This change causes them to be run via execute like `drop table`.