### PR TITLE
Fix regex so that only select/pragma use execute

### DIFF
--- a/lib/rqliteDialect.ts
+++ b/lib/rqliteDialect.ts
@@ -13,8 +13,6 @@ const {
   formatQuery,
 } = require("knex/lib/execution/internal/query-executioner");
 
-const EXECUTE_METHODS = ["insert", "update", "counter", "del"];
-
 const getRqliteQueryResults = function (response) {
   // Empty rqlite results are structured as [{}], we have to override this to []
   if (response.results.length === 1) {
@@ -133,13 +131,10 @@ class RqliteDialect extends knex.Client {
   async _query(connection, obj) {
     let sql = formatQuery(obj.sql, obj.bindings, undefined, this);
 
-    let useExecute = false;
-    if (obj.method) {
-      useExecute = EXECUTE_METHODS.indexOf(obj.method) > -1;
-    }
+    let useExecute = true;
 
-    if (/^(drop|create|alter) table\s+/.test(sql)) {
-      useExecute = true;
+    if (/^(select|pragma)\s+/i.test(sql)) {
+      useExecute = false;
     }
 
     let response;


### PR DESCRIPTION
Hi, it seems rqlite uses `/db/query` path only for the SELECT and PRAGMA query.
(https://github.com/rqlite/rqlite/blob/master/cmd/rqlite/main.go#L179-L182)

However current version of knex-rqlite uses `/db/query` path in some cases when attempting to change database.
```
Error: create unique index `my_unique_index` on `my_table` (`my_column`)   
- Query resulted in an error: 'attempt to change database via query operation
```